### PR TITLE
Fix inaccurate version bound on `base`

### DIFF
--- a/gochan.cabal
+++ b/gochan.cabal
@@ -32,7 +32,7 @@ library
     exposed-modules:
         Control.Concurrent.GoChan
     build-depends:
-        base >=4 && <5,
+        base >=4.8 && <5,
         array -any,
         random -any,
         vector -any,


### PR DESCRIPTION
The cabal file claims compatibility with `base >= 4.7`, however GHC 7.8.4 disagrees:

```
Configuring component lib from gochan-0.0.2...
Preprocessing library gochan-0.0.2...
[1 of 1] Compiling Control.Concurrent.GoChan ( src/Control/Concurrent/GoChan.hs, /tmp/matrix-worker/1490079902/dist-newstyle/build/x86_64-linux/ghc-7.8.4/gochan-0.0.2/build/Control/Concurrent/GoChan.o )

src/Control/Concurrent/GoChan.hs:557:35: Not in scope: ‘<$>’

src/Control/Concurrent/GoChan.hs:557:43: Not in scope: ‘<$>’

src/Control/Concurrent/GoChan.hs:568:35: Not in scope: ‘<$>’
cabal: Failed to build gochan-0.0.2 (which is required by exe:weight from
gochan-0.0.2 and exe:bench from gochan-0.0.2).
```